### PR TITLE
Modelling: classes "Eval" and "EvalSuite"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.6"      # current default Python on Travis CI
   - "3.7"
   - "3.8"
 # command to install dependencies

--- a/evalytics/server/adapters.py
+++ b/evalytics/server/adapters.py
@@ -1,14 +1,30 @@
-
-from .models import OrgChart
-
-class FakeAdapter():
-
-    def get_org_chart(self):
-        return OrgChart()
+from .models import Eval, EvalSuite, OrgChart
 
 
-class GoogleSheetsAdapter():
+class OrgChartAdapter:
 
-    def get_org_chart(self):
-        # TODO: This adapter talks with google sheets api and returns an OrgChart model
-        return OrgChart()
+    def create_initial_eval_suite(
+            self, org_chart: OrgChart, consider_peers=None) -> EvalSuite:
+        """OrgChart => EvalSuite
+
+        by default it will only consider a '180' eval
+        """
+        eval_suite = EvalSuite()
+
+        for employee in org_chart:
+            eval_suite.add_eval(Eval.new_self_eval(employee))
+
+            supervisor = employee.parent
+            if supervisor:
+                eval_suite.add_eval(
+                    Eval.new_supervisor_eval(employee, supervisor))
+                if consider_peers:
+                    for peer in supervisor.minions:
+                        if peer is not employee:
+                            eval_suite.add_eval(
+                                Eval.new_peer_eval(employee, peer))
+
+            for minion in employee.minions:
+                eval_suite.add_eval(Eval.new_minion_eval(employee, minion))
+
+        return eval_suite

--- a/evalytics/server/models.py
+++ b/evalytics/server/models.py
@@ -1,8 +1,11 @@
+from dataclasses import dataclass
+from enum import Enum
 from typing import Iterable
 
 from anytree import NodeMixin, PreOrderIter, RenderTree
 
 
+@dataclass
 class Employee(NodeMixin):
     """Tree-Node functionallity
     Base model for building the OrgChart
@@ -52,7 +55,74 @@ class OrgChart:
         self.root = root
 
     def __iter__(self):
-        return PreOrderIter(self.root)
+        return iter(PreOrderIter(self.root))
 
     def __str__(self):
         return '\n'.join(["{0}{1}".format(pre, node) for pre, _, node in RenderTree(self.root)])
+
+    def create_eval_suite(self) -> 'EvalSuite':
+        evals = []
+        for employee in self:
+            evals.append(Eval.new_self_eval(employee))
+
+            supervisor = employee.parent
+            if supervisor:
+                evals.append(
+                    Eval.new_supervisor_eval(employee, supervisor)
+                )
+                for peer in supervisor.minions:
+                    if peer is not employee:
+                        evals.append(Eval.new_peer_eval(employee, peer))
+
+            for minion in employee.minions:
+                evals.append(Eval.new_minion_eval(employee, minion))
+
+        return EvalSuite(evals)
+
+
+class EvalType(Enum):
+    SELF = 1
+    PEER = 2
+    MY_SUPERVISOR = 3
+    MY_MINION = 4
+
+
+@dataclass
+class Eval:
+    """
+    examples;
+
+        <Eval: jhon --> Jane (MY_SUPERVISOR)>
+        <Eval: minion3 --> minion3 (SELF)>
+    """
+
+    def __init__(self, from_: Employee, to_: Employee, type_: EvalType):
+        self.from_ = from_
+        self.to_ = to_
+        self.type_ = type_
+
+    def __repr__(self):
+        return '<Eval: {0.from_.name} --> {0.to_.name} ({0.type_.name})>'\
+            .format(self)
+
+    @classmethod
+    def new_self_eval(cls, who: Employee) -> 'Eval':
+        return cls(who, who, EvalType.SELF)
+
+    @classmethod
+    def new_peer_eval(cls, who: Employee, peer: Employee) -> 'Eval':
+        return cls(who, peer, EvalType.PEER)
+
+    @classmethod
+    def new_supervisor_eval(cls, who: Employee, supervisor: Employee) -> 'Eval':
+        return cls(who, supervisor, EvalType.MY_SUPERVISOR)
+
+    @classmethod
+    def new_minion_eval(cls, who: Employee, minion: Employee) -> 'Eval':
+        return cls(who, minion, EvalType.MY_MINION)
+
+
+class EvalSuite:
+
+    def __init__(self, initial_evals: Iterable[Eval]):
+        self.initial_evals = initial_evals

--- a/evalytics/server/models.py
+++ b/evalytics/server/models.py
@@ -60,25 +60,6 @@ class OrgChart:
     def __str__(self):
         return '\n'.join(["{0}{1}".format(pre, node) for pre, _, node in RenderTree(self.root)])
 
-    def create_eval_suite(self) -> 'EvalSuite':
-        evals = []
-        for employee in self:
-            evals.append(Eval.new_self_eval(employee))
-
-            supervisor = employee.parent
-            if supervisor:
-                evals.append(
-                    Eval.new_supervisor_eval(employee, supervisor)
-                )
-                for peer in supervisor.minions:
-                    if peer is not employee:
-                        evals.append(Eval.new_peer_eval(employee, peer))
-
-            for minion in employee.minions:
-                evals.append(Eval.new_minion_eval(employee, minion))
-
-        return EvalSuite(evals)
-
 
 class EvalType(Enum):
     SELF = 1
@@ -101,7 +82,7 @@ class Eval:
         self.to_ = to_
         self.type_ = type_
 
-    def __repr__(self):
+    def __str__(self):
         return '<Eval: {0.from_.name} --> {0.to_.name} ({0.type_.name})>'\
             .format(self)
 
@@ -121,8 +102,11 @@ class Eval:
     def new_minion_eval(cls, who: Employee, minion: Employee) -> 'Eval':
         return cls(who, minion, EvalType.MY_MINION)
 
-
+@dataclass
 class EvalSuite:
 
-    def __init__(self, initial_evals: Iterable[Eval]):
-        self.initial_evals = initial_evals
+    def __init__(self):
+        self.evals = []
+
+    def add_eval(self, eval: Eval):
+        self.evals.append(eval)

--- a/evalytics/server/repositories.py
+++ b/evalytics/server/repositories.py
@@ -1,0 +1,6 @@
+class FakeRepository():
+    pass
+
+
+class GoogleSheetsRepository():
+    pass

--- a/evalytics/tests/test_org_chart.py
+++ b/evalytics/tests/test_org_chart.py
@@ -24,27 +24,3 @@ class TestOrgChart(TestCase):
     def test_org_chart_may_be_iterated(self):
         for employee in self.org_chart:
             self.assertIsInstance(employee, Employee)
-
-    def test_org_chart_creates_an_eval_suite(self):
-        eval_suite = self.org_chart.create_eval_suite()
-        self.assertListEqual(eval_suite.initial_evals, [
-            Eval(jane, jane, EvalType.SELF),
-            Eval(jane, jhon, EvalType.MY_MINION),
-            Eval(jhon, jhon, EvalType.SELF),
-            Eval(jhon, jane, EvalType.MY_SUPERVISOR),
-            Eval(jhon, minion_1, EvalType.MY_MINION),
-            Eval(jhon, minion_2, EvalType.MY_MINION),
-            Eval(jhon, minion_3, EvalType.MY_MINION),
-            Eval(minion_1, minion_1, EvalType.SELF),
-            Eval(minion_1, jhon, EvalType.MY_SUPERVISOR),
-            Eval(minion_1, minion_2, EvalType.PEER),
-            Eval(minion_1, minion_3, EvalType.PEER),
-            Eval(minion_2, minion_2, EvalType.SELF),
-            Eval(minion_2, jhon, EvalType.MY_SUPERVISOR),
-            Eval(minion_2, minion_1, EvalType.PEER),
-            Eval(minion_2, minion_3, EvalType.PEER),
-            Eval(minion_3, minion_3, EvalType.SELF),
-            Eval(minion_3, jhon, EvalType.MY_SUPERVISOR),
-            Eval(minion_3, minion_1, EvalType.PEER),
-            Eval(minion_3, minion_2, EvalType.PEER),
-        ])

--- a/evalytics/tests/test_org_chart.py
+++ b/evalytics/tests/test_org_chart.py
@@ -1,17 +1,19 @@
 from unittest import TestCase
 
-from ..server.models import Employee, OrgChart
+from ..server.models import Employee, Eval, EvalType, OrgChart
+
+# fixtures
+jane = Employee('jane@tuenti.com')
+jhon = Employee('jhon@tuenti.com', supervisor=jane)
+minion_1 = Employee('minion1@tuenti.com', supervisor=jhon)
+minion_2 = Employee('minion2@tuenti.com', supervisor=jhon)
+minion_3 = Employee('minion3@tuenti.com', supervisor=jhon)
 
 
 class TestOrgChart(TestCase):
 
     def setUp(self):
-        jane = Employee('jane@tuenti.com')
-        jhon = Employee('jhon@tuenti.com', supervisor=jane)
-        minion_1 = Employee('minion1@tuenti.com', supervisor=jhon)
-        minion_2 = Employee('minion2@tuenti.com', supervisor=jhon)
-        minion_3 = Employee('minion3@tuenti.com', supervisor=jhon)
-        self.org_chart = OrgChart(jane)
+        self.org_chart = OrgChart(jane)  # subject
 
     def test_org_chart_keeps_the_expected_structure(self):
         minions_names = [
@@ -22,3 +24,27 @@ class TestOrgChart(TestCase):
     def test_org_chart_may_be_iterated(self):
         for employee in self.org_chart:
             self.assertIsInstance(employee, Employee)
+
+    def test_org_chart_creates_an_eval_suite(self):
+        eval_suite = self.org_chart.create_eval_suite()
+        self.assertListEqual(eval_suite.initial_evals, [
+            Eval(jane, jane, EvalType.SELF),
+            Eval(jane, jhon, EvalType.MY_MINION),
+            Eval(jhon, jhon, EvalType.SELF),
+            Eval(jhon, jane, EvalType.MY_SUPERVISOR),
+            Eval(jhon, minion_1, EvalType.MY_MINION),
+            Eval(jhon, minion_2, EvalType.MY_MINION),
+            Eval(jhon, minion_3, EvalType.MY_MINION),
+            Eval(minion_1, minion_1, EvalType.SELF),
+            Eval(minion_1, jhon, EvalType.MY_SUPERVISOR),
+            Eval(minion_1, minion_2, EvalType.PEER),
+            Eval(minion_1, minion_3, EvalType.PEER),
+            Eval(minion_2, minion_2, EvalType.SELF),
+            Eval(minion_2, jhon, EvalType.MY_SUPERVISOR),
+            Eval(minion_2, minion_1, EvalType.PEER),
+            Eval(minion_2, minion_3, EvalType.PEER),
+            Eval(minion_3, minion_3, EvalType.SELF),
+            Eval(minion_3, jhon, EvalType.MY_SUPERVISOR),
+            Eval(minion_3, minion_1, EvalType.PEER),
+            Eval(minion_3, minion_2, EvalType.PEER),
+        ])

--- a/evalytics/tests/test_org_chart_adapter.py
+++ b/evalytics/tests/test_org_chart_adapter.py
@@ -1,0 +1,64 @@
+from unittest import TestCase
+
+from ..server.adapters import OrgChartAdapter
+from ..server.models import Employee, Eval, EvalSuite, EvalType, OrgChart
+
+# fixtures
+jane = Employee('jane@tuenti.com')
+jhon = Employee('jhon@tuenti.com', supervisor=jane)
+minion_1 = Employee('minion1@tuenti.com', supervisor=jhon)
+minion_2 = Employee('minion2@tuenti.com', supervisor=jhon)
+minion_3 = Employee('minion3@tuenti.com', supervisor=jhon)
+org_chart = OrgChart(jane)
+
+
+class TestOrgChartAdapter(TestCase):
+
+    def setUp(self):
+        self.org_chart_adapter = OrgChartAdapter()  # subject
+
+    def test_create_initial_180_eval_suite(self):
+        initial_eval_suite = self.org_chart_adapter.create_initial_eval_suite(
+            org_chart)
+
+        self.assertListEqual(initial_eval_suite.evals, [
+            Eval(jane, jane, EvalType.SELF),
+            Eval(jane, jhon, EvalType.MY_MINION),
+            Eval(jhon, jhon, EvalType.SELF),
+            Eval(jhon, jane, EvalType.MY_SUPERVISOR),
+            Eval(jhon, minion_1, EvalType.MY_MINION),
+            Eval(jhon, minion_2, EvalType.MY_MINION),
+            Eval(jhon, minion_3, EvalType.MY_MINION),
+            Eval(minion_1, minion_1, EvalType.SELF),
+            Eval(minion_1, jhon, EvalType.MY_SUPERVISOR),
+            Eval(minion_2, minion_2, EvalType.SELF),
+            Eval(minion_2, jhon, EvalType.MY_SUPERVISOR),
+            Eval(minion_3, minion_3, EvalType.SELF),
+            Eval(minion_3, jhon, EvalType.MY_SUPERVISOR),
+        ])
+
+    def test_create_initial_180_eval_suite_considering_peers(self):
+        initial_eval_suite = self.org_chart_adapter.create_initial_eval_suite(
+            org_chart, consider_peers=True)
+
+        self.assertListEqual(initial_eval_suite.evals, [
+            Eval(jane, jane, EvalType.SELF),
+            Eval(jane, jhon, EvalType.MY_MINION),
+            Eval(jhon, jhon, EvalType.SELF),
+            Eval(jhon, jane, EvalType.MY_SUPERVISOR),
+            Eval(jhon, minion_1, EvalType.MY_MINION),
+            Eval(jhon, minion_2, EvalType.MY_MINION),
+            Eval(jhon, minion_3, EvalType.MY_MINION),
+            Eval(minion_1, minion_1, EvalType.SELF),
+            Eval(minion_1, jhon, EvalType.MY_SUPERVISOR),
+            Eval(minion_1, minion_2, EvalType.PEER),
+            Eval(minion_1, minion_3, EvalType.PEER),
+            Eval(minion_2, minion_2, EvalType.SELF),
+            Eval(minion_2, jhon, EvalType.MY_SUPERVISOR),
+            Eval(minion_2, minion_1, EvalType.PEER),
+            Eval(minion_2, minion_3, EvalType.PEER),
+            Eval(minion_3, minion_3, EvalType.SELF),
+            Eval(minion_3, jhon, EvalType.MY_SUPERVISOR),
+            Eval(minion_3, minion_1, EvalType.PEER),
+            Eval(minion_3, minion_2, EvalType.PEER),
+        ])


### PR DESCRIPTION
- EvalSuite is a wrapper over a list of Evals

- Eval is a dataclass with 3 values:
   from, to, type (enum)

- new method at OrgChart
   org_chart.create_eval_suite() -> EvalSuite

example of an eval suite:

```
<Eval: jane --> jane (SELF)>
<Eval: jane --> jhon (MY_MINION)>
<Eval: jhon --> jhon (SELF)>
<Eval: jhon --> jane (MY_SUPERVISOR)>
<Eval: jhon --> minion1 (MY_MINION)>
<Eval: jhon --> minion2 (MY_MINION)>
<Eval: jhon --> minion3 (MY_MINION)>
<Eval: minion1 --> minion1 (SELF)>
<Eval: minion1 --> jhon (MY_SUPERVISOR)>
<Eval: minion1 --> minion2 (PEER)>
<Eval: minion1 --> minion3 (PEER)>
<Eval: minion2 --> minion2 (SELF)>
<Eval: minion2 --> jhon (MY_SUPERVISOR)>
<Eval: minion2 --> minion1 (PEER)>
<Eval: minion2 --> minion3 (PEER)>
<Eval: minion3 --> minion3 (SELF)>
<Eval: minion3 --> jhon (MY_SUPERVISOR)>
<Eval: minion3 --> minion1 (PEER)>
<Eval: minion3 --> minion2 (PEER)>
```